### PR TITLE
Remove the message for HTML5

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -231,6 +231,7 @@ module.exports = {
 	        options.relaxerror.push('The Content-Type was');
 	        options.relaxerror.push('The character encoding was not declared');
 	        options.relaxerror.push('Using the schema for HTML with');
+	        options.relaxerror.push('Using the schema for HTML5 +');
 
 	        // Delete an exist report if present
 	        if (options.reportpath !== null && fs.existsSync(options.reportpath)) {


### PR DESCRIPTION
After following this guide (https://github.com/tlvince/w3c-validator-guide) to install a local validator, I encounter the following validation info message: "Using the schema for HTML5 + SVG 1.1 + MathML 3.0 + RDFa Lite 1.1."

While it can manually be relaxed by being added to the relaxerror option, I think that, in the same spirit as the "Using the schema for HTML with..." message, it should also be automatically relaxed.
