### PR TITLE
add a deep copy of the validation options

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -209,7 +209,9 @@ var finished = function(files, options, fullfill, reject) {
 
 module.exports = {
   validate: function(fileSrcs, opts) {
-    opts = JSON.parse(JSON.stringify(opts));
+    if (opts !== undefined) {
+      opts = JSON.parse(JSON.stringify(opts));
+    }
 
     // Wrap inside a promise object
     return new Promise(function(fullfill, reject) {
@@ -264,6 +266,7 @@ module.exports = {
 
       // Check that we got files
       if (files.length === 0) {
+          console.log('rejected');
         reject('No files found to match');
       }
 

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -209,6 +209,8 @@ var finished = function(files, options, fullfill, reject) {
 
 module.exports = {
   validate: function(fileSrcs, opts) {
+    opts = JSON.parse(JSON.stringify(opts));
+
     // Wrap inside a promise object
     return new Promise(function(fullfill, reject) {
       // Merge options


### PR DESCRIPTION
Since the validate function operates on arrays inside the options object, a deep copy is needed to ensure consistent behavior when the function is called with the same options object multiple times.
