### PR TITLE
Charset detection

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -101,11 +101,12 @@ var validate = function(file, callback) {
     }
 
     // Build temporary file
+    var metaCharset = (options.charset !== false)?'<meta content="text/html;charset=' + options.charset + '" http-equiv="Content-Type">':'';
     fs.writeFileSync(temppath,
       '<!DOCTYPE html>\n' +
       '<html>\n' +
       '<head>' +
-      '<meta content="text/html;charset=' + options.charset + '" http-equiv="Content-Type">' +
+      metaCharset +
       '<title>Dummy</title>' +
       '</head>\n' +
       '<body>\n' +

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -102,9 +102,16 @@ var validate = function(file, callback) {
 
     // Build temporary file
     fs.writeFileSync(temppath,
-      '<!DOCTYPE html>\n<html>\n<head><title>Dummy</title></head>\n<body>\n' +
-      content +
-      '\n</body>\n</html>');
+      '<!DOCTYPE html>\n' +
+      '<html>\n' +
+      '<head>\n' +
+      '<meta content="text/html;charset=' + options.charset + '" http-equiv="Content-Type">\n' +
+      '<title>Dummy</title>\n' +
+      '</head>\n' +
+      '<body>\n' +
+      content + '\n' +
+      '</body>\n' +
+      '</html>');
   }
 
   // Do validation
@@ -112,7 +119,6 @@ var validate = function(file, callback) {
     file: temppath,
     output: 'json',
     doctype: this.doctype,
-    charset: this.charset,
     proxy: this.w3cproxy,
     callback: function(res) {
       // Validate result

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -118,6 +118,7 @@ var validate = function(file, callback) {
     file: temppath,
     output: 'json',
     doctype: this.doctype,
+    charset: this.charset,
     proxy: this.w3cproxy,
     callback: function(res) {
       // Validate result

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -104,14 +104,13 @@ var validate = function(file, callback) {
     fs.writeFileSync(temppath,
       '<!DOCTYPE html>\n' +
       '<html>\n' +
-      '<head>\n' +
-      '<meta content="text/html;charset=' + options.charset + '" http-equiv="Content-Type">\n' +
-      '<title>Dummy</title>\n' +
+      '<head>' +
+      '<meta content="text/html;charset=' + options.charset + '" http-equiv="Content-Type">' +
+      '<title>Dummy</title>' +
       '</head>\n' +
       '<body>\n' +
       content + '\n' +
-      '</body>\n' +
-      '</html>');
+      '</body>\n</html>');
   }
 
   // Do validation


### PR DESCRIPTION
Charset is NOT taken into account (anymore) by w3cjs => do not add it in options (it is unused).
Define the charset directly in the template wrapping (as meta tag).

Note that is "solves" the https://github.com/validator/htmlparser/issues/105 issue (for templates).
