### PR TITLE
Don't throw the "empty heading" error when the element uses ng-bind or ng-bind-html

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -49,6 +49,13 @@ var checkRelaxed = function(errmsg, options) {
   return false;
 };
 
+var checkAngularBindings = function(err, options) {
+  if (options.angular && err.message === 'Empty heading.' && /\sng-bind(-html)?=/.test(err.extract)) {
+    return true;
+  }
+  return false;
+};
+
 var checkCustomTags = function(errmsg, options) {
   for (var i = 0; i < options.customtags.length; i += 1) {
     var re = new RegExp('^Element (.?)' +
@@ -153,6 +160,7 @@ var validate = function(file, callback) {
         for (var i = 0; i < res.messages.length; i += 1) {
           // See if this error message is valid
           if (!checkRelaxed(res.messages[i].message, options) &&
+            !checkAngularBindings(res.messages[i], options) &&
             !checkCustomTags(res.messages[i].message, options) &&
             !checkCustomAttrs(res.messages[i].message, options)) {
             // Store the error message

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "gulp-util": "~3.0.7",
     "js-object-pretty-print": "~0.2.0",
     "jshint": "~2.9.1",
-    "jshint-stylish": "~2.1.0"
+    "jshint-stylish": "~2.1.0",
+    "mocha": "~2.4.5"
   },
   "dependencies": {
     "async": "~1.5.0",

--- a/test/html/valid/template/valid_angular_bindings.tmpl.html
+++ b/test/html/valid/template/valid_angular_bindings.tmpl.html
@@ -1,0 +1,7 @@
+<div id="dvContainer" class="container top-level">
+
+    <h2 ng-bind="userEmail"></h2>
+
+    <h2 ng-bind-html="userEmail"></h2>
+    
+</div>

--- a/test/validateTest.js
+++ b/test/validateTest.js
@@ -141,6 +141,18 @@ describe('Validate', function() {
     });
   });
 
+  it('Correct Template Fragment Using Angular Bindings', function() {
+    return validate.validate([
+      'test/html/valid/template/valid_angular_bindings.tmpl.html'
+    ]).should.eventually.have.properties({
+      allpassed: true,
+      fileschecked: 1,
+      filessucceeded: 1,
+      filesfailed: 0,
+      failed: []
+    });
+  });
+
   it('Invalid Template Fragment with Improperly Closed Tag', function() {
     return validate.validate([
       'test/html/invalid/template/improperly_closed_tag.tmpl.html'


### PR DESCRIPTION
A fix for Issue #11! :tada: 
