### PR TITLE
Ignore errors about missing src attribute when ng-src is present

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -50,8 +50,11 @@ var checkRelaxed = function(errmsg, options) {
 };
 
 var checkAngularBindings = function(err, options) {
-  if (options.angular && err.message === 'Empty heading.' && /\sng-bind(-html)?=/.test(err.extract)) {
-    return true;
+  if (options.angular) {
+    if ((err.message === 'Empty heading.' && /\sng-bind(-html)?=/.test(err.extract)) ||
+      (/^Element “.+” is missing required attribute “src”/.test(err.message) && /\sng-src=/.test(err.extract))) {
+      return true;
+    }
   }
   return false;
 };

--- a/test/html/valid/template/valid_angular_bindings.tmpl.html
+++ b/test/html/valid/template/valid_angular_bindings.tmpl.html
@@ -4,4 +4,14 @@
 
     <h2 ng-bind-html="userEmail"></h2>
     
+    <img ng-src="imgPath" alt="some image">
+    
+    <iframe ng-src="somePath"></iframe>
+    
+    <audio controls>
+        <source ng-src="oggFile" type="audio/ogg">
+        <source ng-src="mpgFile" type="audio/mpeg">
+        Your browser does not support the audio element.
+    </audio>
+    
 </div>


### PR DESCRIPTION
Previously this code

```
<img ng-src="imgPath" alt="some image">
```

would throw the error:

> Element “img” is missing required attribute “src”

Now this error is suppressed when the `ng-src` attribute is present on the element.
