### PR TITLE
W3c timeout error msg

### DIFF
--- a/lib/validate.js
+++ b/lib/validate.js
@@ -127,9 +127,9 @@ var validate = function(file, callback) {
   w3cjs.validate({
     file: temppath,
     output: 'json',
-    doctype: this.doctype,
-    charset: this.charset,
-    proxy: this.w3cproxy,
+    doctype: options.doctype,
+    charset: options.charset,
+    proxy: options.w3cproxy,
     callback: function(res) {
       // Validate result
       if (res === undefined || res.messages === undefined) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -82,6 +82,19 @@ var checkCustomAttrs = function(errmsg, options) {
 
 var validate = function(file, callback) {
   var options = this;
+
+  if (!options) {
+    var errMsg = 'Too many calls to the w3c service! Unable to validate file!';
+    file.errs = [{
+      line: 0,
+      col: 0,
+      msg: errMsg
+    }];
+    callback(errMsg, file);
+    console.log(errMsg);
+    return;
+  }
+
   var temppath = file.path;
 
   // If this is a templated file, we need to wrap it as a full


### PR DESCRIPTION
Typically we get this error thrown:

```
\node_modules\gulp-html-angular-validate\node_modules\html-angular-validate\lib\validate.js:94
    for (var key in options.wrapping) {
                           ^
```

But in reality, the w3c web service has refused the connection due to too many connections.  Now a relevant message is logged instead.
