### PR TITLE
Add support for Component Templates validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,19 @@ Default value: `tmpl.html`
 
 The extension of HTML files that are templated or otherwise not complete and valid HTML files (i.e. do not start and end with `<html>`). The validator will wrap these files as complete HTML pages for validation.
 
+### componentext
+Type: `String`
+Default value: `component.js`
+
+The extension of Angular Component files that have templates (es6 template literals). The validator will extract the template from the component file and it will wrap these templates as complete HTML pages for validation.
+
+The search pattern is anything like this:
+```js
+
+   template: `...`
+
+```
+
 ### doctype
 Type: `String`
 Default value: `HTML5`

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -107,7 +107,24 @@ var wrapTemplate = function(content, charset) {
   return html;
 };
 
+// Extract the template between backticks from the component file
+var extractComponentTemplate = function(file, content) {
+  var templateMatches = content.match(
+    /template:\s*\`((\s*)|(.*))[^\`]*\`/gm
+  );
+  if (templateMatches && templateMatches.length > 0) {
+    content = templateMatches.map(function(template) {
+      return template.match(/[^\`]((\s*)|(.*))[^\`]*[^\`]/gm)[1];
+    });
+  // If there's no template in the file, reset the content in order to not validate
+  } else {
+    content = null;
+  }
+  return content;
+};
+
 var validate = function(file, callback) {
+
   var options = this;
 
   // If this is a templated file, we need to wrap it as a full
@@ -142,21 +159,11 @@ var validate = function(file, callback) {
 
     // If the file is a component, try to extract the template between backticks
     if (file.isComponent) {
-      var templateMatches = content.match(
-        /template:\s*\`((\s*)|(.*))[^\`]*\`/gm
-      );
-      if (templateMatches && templateMatches.length > 0) {
-        var templateString = templateMatches.map(function(template) {
-          return template.match(/\`((\s*)|(.*))[^\`]*\`/gm);
-        });
-
-        content = wrapTemplate(templateString, options.charset);
-      }
-    // instead, write out temporary file
-    } else {
-      try { fs.writeFileSync(tmpFile, wrapTemplate(content, options.charset)); }
-      catch (error) { return callback(error, file); }
+      content = extractComponentTemplate(file, content);
     }
+    // Write out temporary file
+    try { fs.writeFileSync(tmpFile, wrapTemplate(content, options.charset)); }
+    catch (error) { return callback(error, file); }
   }
 
   var validationOptions = {
@@ -166,12 +173,7 @@ var validate = function(file, callback) {
     proxy: this.w3cproxy
   };
 
-  // If the file is a component, use the template string as the input
-  if (file.isComponent) {
-    validationOptions.input = content;
-  } else {
-    validationOptions.file = tmpFile || file.path;
-  }
+  validationOptions.file = tmpFile || file.path;
   validationOptions.callback = function(error, res) {
     // Check for validator error
     if (error) {

--- a/lib/validate.js
+++ b/lib/validate.js
@@ -29,6 +29,7 @@ var defaultOpts = {
   wrapping: {},
   relaxerror: [],
   tmplext: 'tmpl.html',
+  componentext: 'component.js',
   doctype: 'HTML5',
   charset: 'utf-8',
   reportpath: 'html-angular-validate-report.json',
@@ -112,18 +113,19 @@ var validate = function(file, callback) {
   // If this is a templated file, we need to wrap it as a full
   // document in a temporary file
   var tmpFile = null;
-  if (file.istmpl) {
+  // Create a wrapped file to pass to the validator
+  var content = null;
+  if (file.istmpl || file.isComponent) {
     // Create a temporary file
     tmpFile = crypto.randomBytes(4).toString('hex');
     tmpFile = 'html-angular-validate-' + tmpFile + '.html';
     tmpFile = path.join(os.tmpdir(), tmpFile);
 
-    // Create a wrapped file to pass to the validator
-    var content = null;
     try {
       content = fs.readFileSync(file.path, {
         encoding: 'utf8'
       }).trim();
+
     } catch (error) {
       return callback(error, file);
     }
@@ -138,80 +140,100 @@ var validate = function(file, callback) {
       }
     }
 
-    // Write out temporary file
-    try { fs.writeFileSync(tmpFile, wrapTemplate(content, options.charset)); }
-    catch (error) { return callback(error, file); }
+    // If the file is a component, try to extract the template between backticks
+    if (file.isComponent) {
+      var templateMatches = content.match(
+        /template:\s*\`((\s*)|(.*))[^\`]*\`/gm
+      );
+      if (templateMatches && templateMatches.length > 0) {
+        var templateString = templateMatches.map(function(template) {
+          return template.match(/\`((\s*)|(.*))[^\`]*\`/gm);
+        });
 
+        content = wrapTemplate(templateString, options.charset);
+      }
+    // instead, write out temporary file
+    } else {
+      try { fs.writeFileSync(tmpFile, wrapTemplate(content, options.charset)); }
+      catch (error) { return callback(error, file); }
+    }
   }
 
-  // Do validation
-  w3cjs.validate({
-    file: tmpFile || file.path,
+  var validationOptions = {
     output: 'json',
     doctype: this.doctype,
     charset: this.charset,
-    proxy: this.w3cproxy,
-    callback: function(error, res) {
-      // Check for validator error
-      if (error) {
-        callback(new Error('Unable to validate file'), error);
-      }
+    proxy: this.w3cproxy
+  };
 
-      // Validate result
-      if (!res || !res.messages) {
-        // Something went wrong
-        //   See if we should try again or fail this file and
-        //   move on
-        if (file.attempts < options.maxvalidateattempts) {
-          // Increment the attempt count and try again
-          file.attempts += 1;
-          validate(file, callback);
-        } else {
-          // Fail the file and stop remaining validations
-          // Clean up if it is a template file
-          file.seenerrs = true;
-          file.errs = [{
-            line: 0,
-            col: 0,
-            msg: 'Unable to validate file'
-          }];
-          if (tmpFile !== null) {
-            try { fs.unlinkSync(tmpFile); }
-            catch (error) { return callback(error, file); }
-          }
-          callback(new Error('Unable to check file'), file);
-        }
+  // If the file is a component, use the template string as the input
+  if (file.isComponent) {
+    validationOptions.input = content;
+  } else {
+    validationOptions.file = tmpFile || file.path;
+  }
+  validationOptions.callback = function(error, res) {
+    // Check for validator error
+    if (error) {
+      callback(new Error('Unable to validate file'), error);
+    }
+
+    // Validate result
+    if (!res || !res.messages) {
+      // Something went wrong
+      //   See if we should try again or fail this file and
+      //   move on
+      if (file.attempts < options.maxvalidateattempts) {
+        // Increment the attempt count and try again
+        file.attempts += 1;
+        validate(file, callback);
       } else {
-        // Handle results
-        var errFound = false;
-        for (var i = 0; i < res.messages.length; i += 1) {
-          // See if this error message is valid
-          if (!checkRelaxed(res.messages[i].message, options) &&
-            !checkAngularBindings(res.messages[i], options) &&
-            !checkCustomTags(res.messages[i].message, options) &&
-            !checkCustomAttrs(res.messages[i].message, options)) {
-            // Store the error message
-            errFound = true;
-            file.seenerrs = true;
-            file.errs.push({
-              line: (file.istmpl) ? res.messages[i].lastLine - 4 : res.messages[i].lastLine,
-              col: res.messages[i].lastColumn,
-              msg: res.messages[i].message
-            });
-          }
-        }
-
-        // Clean up temporary file if needed
+        // Fail the file and stop remaining validations
+        // Clean up if it is a template file
+        file.seenerrs = true;
+        file.errs = [{
+          line: 0,
+          col: 0,
+          msg: 'Unable to validate file'
+        }];
         if (tmpFile !== null) {
           try { fs.unlinkSync(tmpFile); }
           catch (error) { return callback(error, file); }
         }
-
-        // Callback: no halting error, success indicator
-        callback(null, file);
+        callback(new Error('Unable to check file'), file);
       }
+    } else {
+      // Handle results
+      var errFound = false;
+      for (var i = 0; i < res.messages.length; i += 1) {
+        // See if this error message is valid
+        if (!checkRelaxed(res.messages[i].message, options) &&
+          !checkAngularBindings(res.messages[i], options) &&
+          !checkCustomTags(res.messages[i].message, options) &&
+          !checkCustomAttrs(res.messages[i].message, options)) {
+          // Store the error message
+          errFound = true;
+          file.seenerrs = true;
+          file.errs.push({
+            line: (file.istmpl) ? res.messages[i].lastLine - 4 : res.messages[i].lastLine,
+            col: res.messages[i].lastColumn,
+            msg: res.messages[i].message
+          });
+        }
+      }
+
+      // Clean up temporary file if needed
+      if (tmpFile !== null) {
+        try { fs.unlinkSync(tmpFile); }
+        catch (error) { return callback(error, file); }
+      }
+
+      // Callback: no halting error, success indicator
+      callback(null, file);
     }
-  });
+  };
+  // Do validation
+  w3cjs.validate(validationOptions);
 };
 
 var finished = function(files, options, fullfill) {
@@ -356,6 +378,7 @@ module.exports = {
         return {
           path: file,
           istmpl: file.endsWith(options.tmplext),
+          isComponent: file.endsWith(options.componentext),
           attempts: 0,
           seenerrs: false,
           errs: []

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "html-angular-validate",
-  "version": "0.1.9",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/html/invalid/component/missing_closing_tag.component.js
+++ b/test/html/invalid/component/missing_closing_tag.component.js
@@ -1,0 +1,13 @@
+const component = {
+    template: `
+        <div>
+            <div>
+                Some content.
+            </div>
+    `,
+    controller: class ComponentController {
+        constructor() {
+            console.log('This is the constructor')
+        }
+    }
+}

--- a/test/html/invalid/component/two_templates_missing_closing_tag.component.js
+++ b/test/html/invalid/component/two_templates_missing_closing_tag.component.js
@@ -1,0 +1,22 @@
+const component = {
+    template: `
+        <div>
+            <div>
+                Some content.
+            </div>
+    `,
+    controller: class ComponentController {
+        constructor() {
+            console.log('This is the constructor')
+
+            const dialogComponent = {
+                template: `
+                    <div>
+                        <div>
+                            Some content.
+                        </div>
+                `
+            }
+        }
+    }
+}

--- a/test/html/valid/component/valid.component.js
+++ b/test/html/valid/component/valid.component.js
@@ -1,0 +1,19 @@
+const component = {
+    template: `
+        <div id="dvContainer" class="container top-level">
+            <span class="label">Nothing Special Div Fragment</span>
+            <div>
+                <ul>
+                    <li>Item One</li>
+                    <li>Item Two</li>
+                    <li>Item Three</li>
+                </ul>
+            </div>
+        </div>
+    `,
+    controller: class ComponentController {
+        constructor() {
+            console.log('This is the constructor')
+        }
+    }
+}

--- a/test/validateTest.js
+++ b/test/validateTest.js
@@ -75,7 +75,7 @@ describe('Validate', function() {
           'errors': [{
             'col': 16,
             'line': 1,
-            'msg': 'Start tag seen without seeing a doctype first. Expected e.g. “<!DOCTYPE html>”.'
+            'msg': 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.'
           }, {
             'col': 14,
             'line': 2,
@@ -322,7 +322,7 @@ describe('Validate', function() {
           'errors': [{
             'col': 50,
             'line': 1,
-            'msg': 'Start tag seen without seeing a doctype first. Expected e.g. “<!DOCTYPE html>”.'
+            'msg': 'Start tag seen without seeing a doctype first. Expected “<!DOCTYPE html>”.'
           }, {
             'col': 50,
             'line': 1,

--- a/test/validateTest.js
+++ b/test/validateTest.js
@@ -126,6 +126,18 @@ describe('Validate', function() {
     });
   });
 
+  it('Correct Component Template Fragments', function() {
+    return validate.validate([
+      'test/html/valid/component/valid.component.js',
+    ]).should.eventually.have.properties({
+      allpassed: true,
+      fileschecked: 1,
+      filessucceeded: 1,
+      filesfailed: 0,
+      failed: []
+    });
+  });
+
   it('Correct Template Fragment with Custom Tag', function() {
     return validate.validate([
       'test/html/valid/template/valid_angular_custom.tmpl.html'
@@ -231,6 +243,62 @@ describe('Validate', function() {
           }, {
             'col': 5,
             'line': 1,
+            'msg': 'Unclosed element “div”.'
+          }]
+        },
+      ]
+    });
+  });
+  it('Invalid Component Template Fragment with Missing Closing Tag', function() {
+    return validate.validate([
+      'test/html/invalid/component/missing_closing_tag.component.js',
+    ]).should.eventually.have.properties({
+      allpassed: false,
+      fileschecked: 1,
+      filessucceeded: 0,
+      filesfailed: 1,
+      failed: [
+
+        {
+          'filepath': 'test/html/invalid/component/missing_closing_tag.component.js',
+          'numerrs': 2,
+          'errors': [{
+            'col': 7,
+            'line': 11,
+            'msg': 'End tag for  “body” seen, but there were unclosed elements.'
+          }, {
+            'col': 13,
+            'line': 6,
+            'msg': 'Unclosed element “div”.'
+          }]
+        },
+      ]
+    });
+  });
+  it('Invalid Component with 2 Template Fragments with Missing Closing Tag', function() {
+    return validate.validate([
+      'test/html/invalid/component/two_templates_missing_closing_tag.component.js',
+    ]).should.eventually.have.properties({
+      allpassed: false,
+      fileschecked: 1,
+      filessucceeded: 0,
+      filesfailed: 1,
+      failed: [
+
+        {
+          'filepath': 'test/html/invalid/component/two_templates_missing_closing_tag.component.js',
+          'numerrs': 3,
+          'errors': [{
+            'col': 7,
+            'line': 16,
+            'msg': 'End tag for  “body” seen, but there were unclosed elements.'
+          }, {
+            'col': 25,
+            'line': 11,
+            'msg': 'Unclosed element “div”.'
+          }, {
+            'col': 13,
+            'line': 6,
             'msg': 'Unclosed element “div”.'
           }]
         },


### PR DESCRIPTION
This PR adds support to validate component templates (es6 template literals) inside JS as explained in #26.
These templates will use the same treatment as a regular template when validating.